### PR TITLE
Lower mem on select query / file write mode.

### DIFF
--- a/lib/salesforce_bulk.rb
+++ b/lib/salesforce_bulk.rb
@@ -22,7 +22,7 @@ module SalesforceBulk
     def update(sobject, records, wait=false)
       self.do_operation('update', sobject, records, nil, wait)
     end
-    
+
     def create(sobject, records, wait=false)
       self.do_operation('insert', sobject, records, nil, wait)
     end
@@ -31,11 +31,11 @@ module SalesforceBulk
       self.do_operation('delete', sobject, records, nil, wait)
     end
 
-    def query(sobject, query)
-      self.do_operation('query', sobject, query, nil)
+    def query(sobject, query, save_to=nil)
+      self.do_operation('query', sobject, query, nil, false, save_to)
     end
 
-    def do_operation(operation, sobject, records, external_field, wait=false)
+    def do_operation(operation, sobject, records, external_field, wait=false, save_to=nil)
       job = SalesforceBulk::Job.new(operation, sobject, records, external_field, @connection)
 
       # TODO: put this in one function
@@ -55,9 +55,9 @@ module SalesforceBulk
           end
           sleep(2) # wait x seconds and check again
         end
-        
+
         if state == 'Completed'
-          job.get_batch_result()
+          job.get_batch_result(save_to)
           job
         else
           job.result.message = "There is an error in your job. The response returned a state of #{state}. Please check your query/parameters and try again."

--- a/lib/salesforce_bulk/job.rb
+++ b/lib/salesforce_bulk/job.rb
@@ -127,11 +127,10 @@ module SalesforceBulk
     end
 
     def parse_results(response, save_to = nil)
-      response.force_encoding('utf-8')
       @result.success = true
 
       if save_to
-        IO.write(save_to, response)
+        IO.binwrite(save_to, response)
         return
       end
 

--- a/lib/salesforce_bulk/job.rb
+++ b/lib/salesforce_bulk/job.rb
@@ -102,7 +102,7 @@ module SalesforceBulk
       end
     end
 
-    def get_batch_result(save_to)
+    def get_batch_result(save_to=nil)
       path = "job/#{@@job_id}/batch/#{@@batch_id}/result"
       headers = Hash["Content-Type" => "text/xml; charset=UTF-8"]
 


### PR DESCRIPTION
SELECT Query時にメモリを非常に消費するため、対策を講じました。

ひとつは、CSV.parse して each_with_index していた部分を CSV.new してshift していく
形をとりました。

ただ上記の状態でもメモリ消費が完全に減ったとは言えない
（ループ内で、すべてのCSV::Row を都度 `@result.records` にpushしているため）
状態だったので、 `save_to` オプションを付加し、ここにファイルパスが入っていれば
生の状態のCSVをファイルに書き出して処理を終了するようにしました。

お気付きの点などあれば指摘いただけると幸いです。

（おそらく現行のプロダクト / バッチ系 で、SFDCからの取得を行おうとしているのは
　今回開発中の部分のみだと思われますが、従来の取得方法でも互換を保つようにしてあります）

確認しておくべきこと

 - [x] 通常のupsertの方には影響がないこと